### PR TITLE
feat: Migrate place fetching to Google Places API

### DIFF
--- a/src/components/Place/PlacesGrid.tsx
+++ b/src/components/Place/PlacesGrid.tsx
@@ -8,7 +8,7 @@ export default function PlacesGrid() {
     const { tripId, dayNumber } = useParams();
     const { data: places, isLoading, isError, error } = useQuery({
         queryKey: ["places"],
-        queryFn: fetchPlaces,
+        queryFn: () => fetchPlaces({query: "breakfast", location: { lat: 46.2044, lng: 6.1432 }}),
     });
 
     function handlePlaceClick(placeId: string) {

--- a/src/pages/EventFormPage.tsx
+++ b/src/pages/EventFormPage.tsx
@@ -33,7 +33,7 @@ export default function EventFormPage() {
         error: tripError,
     } = useQuery<Trip>({
         queryKey: ["trip", tripId],
-        queryFn: ({ signal }) => fetchTrip({ signal, tripId }),
+        queryFn: () => fetchTrip({ tripId }),
     });
 
     const {


### PR DESCRIPTION
📌 What does this PR do?
This PR replaces the local dummy database implementation of place data with live data from the Google Places API. It migrates both the PlacesListPage (used for selecting a place) and the EventFormPage (used for configuring a trip event) to use real-time Google data.

✅ Implemented Features
✔ Replaced dummy JSON-server-based place fetching in PlacesListPage with Place.searchByText() from the Google Maps JS API
✔ Migrated EventFormPage to use Place.fetchFields() to retrieve detailed information by place ID
✔ Preserved existing app types (Place) while mapping new Google data formats