### PR TITLE
fix: Fix Trip Edit UI Bugs & Add Optimistic Trip Image Update

### DIFF
--- a/src/components/Trip/TripHeader/TripDestinationEditor.tsx
+++ b/src/components/Trip/TripHeader/TripDestinationEditor.tsx
@@ -78,9 +78,13 @@ export default function TripDestinationEditor({ destination, tripId, }: TripDest
         enabled: !!debouncedQuery,
     });
 
-    function handleSelect(description: string) {
-        if (description !== destination) {
-            mutateDestination({ tripId, destination: description });
+    function handleSelect(newDestination: string) {
+        if (newDestination !== destination) {
+            mutateDestination({ tripId, destination: newDestination });
+            setOpen(false)
+            setQuery("");
+        } else {
+            toast.error("New destination cannot be the same as previous one.", { id: "trip-destination-update" })
         }
     }
 
@@ -99,7 +103,12 @@ export default function TripDestinationEditor({ destination, tripId, }: TripDest
                     <Pencil className="size-4 text-red-400 opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity" />
                 </div>
             </PopoverTrigger>
-            <PopoverContent className="w-[300px] max-h-256 overflow-y-auto p-0" side="bottom" align="start" avoidCollisions={false}>
+            <PopoverContent
+                className="w-[300px] max-h-256 overflow-y-auto p-0"
+                side="bottom"
+                align="start"
+                avoidCollisions={false}
+            >
                 <Command shouldFilter={false}>
                     <CommandInput
                         placeholder="Search for a destination..."

--- a/src/components/Trip/TripHeader/TripNameEditor.tsx
+++ b/src/components/Trip/TripHeader/TripNameEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState, useEffect } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { updateTripName } from "@/api/trips";
 import { queryClient } from "@/api/queryClient";
@@ -14,8 +14,14 @@ interface TripNameEditorProps {
 }
 
 export default function TripNameEditor({ name, tripId }: TripNameEditorProps) {
-  const nameInputRef = useRef<HTMLInputElement>(null);
   const [editing, setEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(name);
+
+  // Keep inputValue in sync if prop changes while not editing
+  // Optional: If you want to sync external name updates
+  useEffect(() => {
+    if (!editing) setInputValue(name);
+  }, [name]);
 
   const { mutate: mutateName } = useMutation({
     mutationFn: updateTripName,
@@ -39,9 +45,6 @@ export default function TripNameEditor({ name, tripId }: TripNameEditorProps) {
       const updatedTripData = { ...previousTripData, name };
       queryClient.setQueryData(["trips", { tripId }], updatedTripData);
 
-      // Exit editing mode after local cache has been updated to not flash previous, not-updated name
-      setEditing(false);
-
       // Pass previous state to onError for potential rollback
       return { previousTripData };
     },
@@ -63,19 +66,18 @@ export default function TripNameEditor({ name, tripId }: TripNameEditorProps) {
   });
 
   function commitChange() {
-    const newName = nameInputRef.current?.value?.trim();
+    const newName = inputValue.trim();
 
-    // Validate and check if changed
-    if (newName && newName !== name) {
+    if (newName !== name) {
       if (isValidTripName(newName)) {
-        // Don't immediately exit editing to not flash the previous not updated name in cache
         mutateName({ tripId, name: newName });
+        setEditing(false);
       } else {
         toast.error("Trip name must be between 3-100 characters");
+        setInputValue(name);
         setEditing(false);
       }
     } else {
-      // If text didn't change, exit editing mode
       setEditing(false);
     }
   }
@@ -84,16 +86,24 @@ export default function TripNameEditor({ name, tripId }: TripNameEditorProps) {
     <div className="group flex items-center gap-2" onClick={() => setEditing(true)}>
       {editing ? (
         <Input
-          ref={nameInputRef}
-          defaultValue={name}
+          value={inputValue}
+          onChange={e => setInputValue(e.target.value)}
           onBlur={commitChange}
           autoFocus
           className="-ml-[15px] text-3xl font-bold h-auto border-1 border-gray-300 focus-within:border-ring focus-within:ring-3"
+          onKeyDown={e => {
+            if (e.key === "Enter") {
+              commitChange();
+            } else if (e.key === "Escape") {
+              setInputValue(name);
+              setEditing(false);
+            }
+          }}
         />
       ) : (
         <>
           <h1 className="-ml-[3px] text-3xl font-bold py-1 border-1 border-transparent break-all">
-            {name}
+            {inputValue}
           </h1>
           <Pencil className="shrink-0 size-5 text-red-400 opacity-100 sm:opacity-0 group-hover:opacity-100 transition-opacity" />
         </>
@@ -101,3 +111,7 @@ export default function TripNameEditor({ name, tripId }: TripNameEditorProps) {
     </div>
   );
 }
+
+
+
+

--- a/src/components/Trip/TripImageChangeDialog.tsx
+++ b/src/components/Trip/TripImageChangeDialog.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { updateTripImage } from "@/api/trips";
 import { IMAGE_PRESETS } from "@/constants/tripImages";
 import { queryClient } from "@/api/queryClient";
+import { Trip } from "@/types/trip";
 
 interface TripImageChangeDialogProps {
   open: boolean;
@@ -17,22 +18,55 @@ export default function TripImageChangeDialog({ open, onClose, tripId }: TripIma
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
 
   const { mutate: updateImage, isPending } = useMutation({
-    mutationFn: () => updateTripImage({ tripId, imageUrl: selectedUrl }),
-    onError: () => toast.error("Failed to update image", { id: "update-trip-image" }),
-    onSuccess: () => {
-      toast.success("Image updated", { id: "update-trip-image" });
-      queryClient.invalidateQueries({ queryKey: ["trips", { tripId: tripId }] });
-      setSelectedUrl(null);
-      onClose();
+    mutationFn: updateTripImage,
+
+    // Optimistic update
+    onMutate: async () => {
+      toast.success("Trip image updated", { id: "update-trip-image" });
+
+      // Cancel ongoing trip queries
+      await queryClient.cancelQueries({ queryKey: ["trips", { tripId }] });
+
+      // Snapshot previous data
+      const previousTripData = queryClient.getQueryData<Trip>(["trips", { tripId }]);
+      if (!previousTripData) {
+        throw new Error("Cannot optimistically update: trip data is missing from cache");
+      }
+
+      // Optimistically update image in cache
+      queryClient.setQueryData(["trips", { tripId }], {
+        ...previousTripData,
+        image: selectedUrl,
+      });
+
+      // Pass snapshot for rollback
+      return { previousTripData };
+    },
+
+    // Rollback on error
+    onError: (_err, _data, context) => {
+      toast.error("Failed to update image", { id: "update-trip-image" });
+
+      const previousTripData = context?.previousTripData;
+      if (previousTripData) {
+        queryClient.setQueryData(["trips", { tripId }], previousTripData);
+      }
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["trips", { tripId }] });
     },
   });
 
-  function handleImageClick({ url }: { url: string }) {
-    setSelectedUrl(url);
+  function handleUpdateImage() {
+    updateImage({ tripId: tripId, imageUrl: selectedUrl });
+    setSelectedUrl(null)
+    onClose();
   }
 
-  function handleUpdateImage() {
-    updateImage();
+  function handleCancel() {
+    setSelectedUrl(null)
+    onClose();
   }
 
   return (
@@ -46,7 +80,7 @@ export default function TripImageChangeDialog({ open, onClose, tripId }: TripIma
           {IMAGE_PRESETS.map(({ key, label, url }) => (
             <button
               key={key}
-              onClick={() => handleImageClick({ url: url })}
+              onClick={() => setSelectedUrl(url)}
               className={`border-2  ${selectedUrl === url ? "border-red-400" : "border-transparent"}`}
             >
               <img src={url} alt={label} className="object-cover size-full" />
@@ -57,16 +91,16 @@ export default function TripImageChangeDialog({ open, onClose, tripId }: TripIma
         <DialogFooter className="flex justify-end gap-2 mt-4">
           <Button
             variant="secondary"
-            onClick={onClose}
+            onClick={handleCancel}
             disabled={isPending}
-            className="w-auto h-12 bg-gray-100 text-red-400 shadow-md rounded-lg"
+            className="h-12 bg-transparent shadow-none border-none text-black rounded-lg"
           >
             Cancel
           </Button>
           <Button
             onClick={handleUpdateImage}
             disabled={!selectedUrl || isPending}
-            className="w-auto h-12 bg-red-400 text-white shadow-md rounded-lg"
+            className="w-auto h-12 bg-red-400 text-white rounded-lg"
           >
             Confirm
           </Button>


### PR DESCRIPTION
### 📌 What does this PR do?
This PR addresses several UI bugs in the trip editing experience and introduces optimistic updates for trip image selection, resulting in a smoother and more responsive user interface.

### ✅ Implemented Features & Fixes
✔ **Destination editor now closes after choosing a new destination**
The destination picker popover automatically closes after a successful selection, improving user workflow and reducing extra clicks.

✔ **Prevent trip name from flashing previous value after update**
Fixes an issue where the trip name would momentarily display the old value after an update due to delayed cache/server sync, resulting in a cleaner, flicker-free inline editing experience.

✔ **Add optimistic updates to trip image updating**
Switching the trip image is now instant and reflected immediately in the UI before server confirmation, enhancing the perceived speed and responsiveness of the trip image editor.